### PR TITLE
fix(export): 新增了导入导出时读取的一些字段，支持倾斜度和更多图形类型

### DIFF
--- a/experiments/fh6_layer_dump_restore/fh6_layer_dump_restore.py
+++ b/experiments/fh6_layer_dump_restore/fh6_layer_dump_restore.py
@@ -142,12 +142,27 @@ def export_dump(args):
     for index, pointer in iter_layer_pointers(pid, table_address, max_layers):
         raw = read_process_memory(pid, pointer, blob_size)
         if len(raw) != blob_size:
-            raise RuntimeError(f"Layer {index} short read: {len(raw)} / {blob_size} bytes.")
+            print(f"Layer {index} short read ({len(raw)} bytes), skipping.", flush=True)
+            layers.append({
+                "index": index,
+                "pointer": pointer,
+                "summary": None,
+                "blob_b64": None,
+                "extra_fragments": {},
+                "skipped": True,
+            })
+            continue
+        extra_frags = {}
+        if len(raw) >= 0x7C:
+            extra_frags["0x38"] = base64.b64encode(raw[0x38:0x40]).decode("ascii")
+            extra_frags["0x48"] = base64.b64encode(raw[0x48:0x60]).decode("ascii")
+            extra_frags["0x68"] = base64.b64encode(raw[0x68:0x7C]).decode("ascii")
         layers.append({
             "index": index,
             "pointer": pointer,
             "summary": summarize_blob(raw, profile),
             "blob_b64": base64.b64encode(raw).decode("ascii"),
+            "extra_fragments": extra_frags,
         })
         if index == 0 or (index + 1) % 100 == 0 or index + 1 == max_layers:
             print(f"Exported layer {index + 1}/{max_layers}", flush=True)
@@ -254,21 +269,65 @@ def restore_known_fields(args):
     if args.max_layers:
         limit = min(limit, int(args.max_layers))
 
-    specs = [
-        (name, getattr(profile, offset_attr), size)
-        for name, offset_attr, size in KNOWN_FIELD_SPECS
-    ]
+    SHAPE_SCALE_DIVISOR = {102: 63}
+
     for item in layers[:limit]:
         index = int(item["index"])
         if index >= layer_count:
             continue
-        raw = base64.b64decode(item["blob_b64"])
+        if item.get("skipped"):
+            if index == 0 or (index + 1) % 100 == 0 or index + 1 == limit:
+                print(f"Skipping layer {index + 1}/{limit} (unreadable in dump)", flush=True)
+            continue
         pointer = dereference_pointer(pid, table_address + index * 8)
-        for _name, offset, size in specs:
-            write_process_memory(pid, pointer + offset, raw[offset:offset + size])
+        if not pointer:
+            print(f"Layer {index + 1}/{limit} pointer is null, skipping", flush=True)
+            continue
+
+        summary = item.get("summary")
+        if not summary:
+            continue
+        pos = summary.get("position", [0.0, 0.0])
+        scale = summary.get("scale", [0.0, 0.0])
+        rot = summary.get("rotation", 0.0)
+        color = summary.get("color", [0, 0, 0, 0])
+        mask = summary.get("mask", 0)
+        shape_id = summary.get("shape_id_byte", 0)
+
+        if not pos or len(pos) < 2:
+            pos = [0.0, 0.0]
+        if not scale or len(scale) < 2:
+            scale = [0.0, 0.0]
+        if not color or len(color) < 4:
+            color = [0, 0, 0, 0]
+
+        # 1. Write extra fragments first (our approach: preserves transform matrix)
+        frags = item.get("extra_fragments", {})
+        for offset_str, blob_b64 in frags.items():
+            frag_data = base64.b64decode(blob_b64)
+            frag_offset = int(offset_str, 16)
+            write_process_memory(pid, pointer + frag_offset, frag_data)
+
+        # 2. Write known fields on top (our draw_memory_shape logic)
+        pos_data = struct.pack('f', pos[0]) + struct.pack('f', pos[1])
+        write_process_memory(pid, pointer + profile.layer_position_offset, pos_data)
+
+        divisor = SHAPE_SCALE_DIVISOR.get(shape_id, 127)
+        scale_data = struct.pack('f', scale[0]) + struct.pack('f', scale[1])
+        write_process_memory(pid, pointer + profile.layer_scale_offset, scale_data)
+
+        rot_data = struct.pack('f', rot)
+        write_process_memory(pid, pointer + profile.layer_rotation_offset, rot_data)
+
+        color_data = struct.pack('BBBB', color[0], color[1], color[2], color[3])
+        write_process_memory(pid, pointer + profile.layer_color_offset, color_data)
+
+        write_process_memory(pid, pointer + profile.layer_mask_offset, struct.pack('B', 1 if mask else 0))
+        write_process_memory(pid, pointer + profile.layer_shape_id_offset, struct.pack('B', shape_id))
+
         if index == 0 or (index + 1) % 100 == 0 or index + 1 == limit:
-            print(f"Restored known fields for layer {index + 1}/{limit}", flush=True)
-    print(f"Restored known fields for {limit} layers.")
+            print(f"Restored layer {index + 1}/{limit} via structured write", flush=True)
+    print(f"Restored {limit} layers using draw_memory_shape logic + extra_fragments.")
 
 
 def restore_fields(args):


### PR DESCRIPTION
经过测试，原有的单一shape id不足以完全覆盖所有类型的图形（似乎是只能覆盖第一页里的图形，尝试导入字母时发现导入的全是第一页的各种形状），且倾斜度未包含在原有的导入流程中。所以对原有的代码进行了修改，增加了如下字段：

1.0x38-0x3F 
2.0x48-0x5F （上面两个字段疑似和shape id存在一定关联）
3.0x68-0x7B（倾斜度存储在0x70中）

其中，0x54-0x5F这一区域在两次导出时一部分图形存在差异，但不导入这一块区域游戏会直接崩溃。

目前能够做到可以任意导出绝大部分形状（因为没有全部测试一遍，可能有缺漏）为json文件，导入时在图层数量较少的情况下（100层左右）可以正常导入绝大部分形状并保存；但在图层数较大时（500层）时在三四百层左右则会崩溃。并且图层数比较少的时候有的时候没法读到图层组，需要手动加一些矩形

这个改动比较小，但是花了我挺多时间测试的，希望能给大佬提供一些帮助



