### PR TITLE
Add optional luma band preprocessing

### DIFF
--- a/config/settings/_default.ini
+++ b/config/settings/_default.ini
@@ -10,4 +10,4 @@ randomSamples = 220000
 saveAt = 500,1000,1500,2000,2500
 saveEvery = 75
 stopAt = 2500
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/_default.ini
+++ b/config/settings/_default.ini
@@ -10,3 +10,4 @@ randomSamples = 220000
 saveAt = 500,1000,1500,2000,2500
 saveEvery = 75
 stopAt = 2500
+preprocessMode = luma_bands

--- a/config/settings/a. keemstar fast - extremely fast.ini
+++ b/config/settings/a. keemstar fast - extremely fast.ini
@@ -10,4 +10,4 @@ randomSamples = 30000
 saveAt = 100,200,300,400,500
 saveEvery = 10
 stopAt = 500
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/a. keemstar fast - extremely fast.ini
+++ b/config/settings/a. keemstar fast - extremely fast.ini
@@ -10,3 +10,4 @@ randomSamples = 30000
 saveAt = 100,200,300,400,500
 saveEvery = 10
 stopAt = 500
+preprocessMode = luma_bands

--- a/config/settings/b. fast - get'er'done.ini
+++ b/config/settings/b. fast - get'er'done.ini
@@ -10,4 +10,4 @@ randomSamples = 60000
 saveAt = 250,500,750,1000
 saveEvery = 20
 stopAt = 1000
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/b. fast - get'er'done.ini
+++ b/config/settings/b. fast - get'er'done.ini
@@ -10,3 +10,4 @@ randomSamples = 60000
 saveAt = 250,500,750,1000
 saveEvery = 20
 stopAt = 1000
+preprocessMode = luma_bands

--- a/config/settings/c. balanced - good quality and speed.ini
+++ b/config/settings/c. balanced - good quality and speed.ini
@@ -10,4 +10,4 @@ randomSamples = 120000
 saveAt = 300,600,900,1200,1500,1800
 saveEvery = 50
 stopAt = 1800
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/c. balanced - good quality and speed.ini
+++ b/config/settings/c. balanced - good quality and speed.ini
@@ -10,3 +10,4 @@ randomSamples = 120000
 saveAt = 300,600,900,1200,1500,1800
 saveEvery = 50
 stopAt = 1800
+preprocessMode = luma_bands

--- a/config/settings/d. slow - conserve shapes.ini
+++ b/config/settings/d. slow - conserve shapes.ini
@@ -10,4 +10,4 @@ randomSamples = 220000
 saveAt = 500,1000,1500,2000,2500
 saveEvery = 75
 stopAt = 2500
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/d. slow - conserve shapes.ini
+++ b/config/settings/d. slow - conserve shapes.ini
@@ -10,3 +10,4 @@ randomSamples = 220000
 saveAt = 500,1000,1500,2000,2500
 saveEvery = 75
 stopAt = 2500
+preprocessMode = luma_bands

--- a/config/settings/e. super slow - best quality.ini
+++ b/config/settings/e. super slow - best quality.ini
@@ -10,4 +10,4 @@ randomSamples = 350000
 saveAt = 500,1000,1500,2000,2500,3000
 saveEvery = 100
 stopAt = 3000
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/e. super slow - best quality.ini
+++ b/config/settings/e. super slow - best quality.ini
@@ -10,3 +10,4 @@ randomSamples = 350000
 saveAt = 500,1000,1500,2000,2500,3000
 saveEvery = 100
 stopAt = 3000
+preprocessMode = luma_bands

--- a/config/settings/f. I hate my GPU.ini
+++ b/config/settings/f. I hate my GPU.ini
@@ -10,4 +10,4 @@ randomSamples = 1000000
 saveAt = 2500,2750,2900
 saveEvery = 50
 stopAt = 2900
-preprocessMode = luma_bands
+preprocessMode = luma_band

--- a/config/settings/f. I hate my GPU.ini
+++ b/config/settings/f. I hate my GPU.ini
@@ -10,3 +10,4 @@ randomSamples = 1000000
 saveAt = 2500,2750,2900
 saveEvery = 50
 stopAt = 2900
+preprocessMode = luma_bands

--- a/src/app.py
+++ b/src/app.py
@@ -1314,7 +1314,7 @@ class App:
             entry.grid(row=row_index, column=1, sticky="ew", pady=1)
             self.custom_fields.append(entry)
         custom_grid.columnconfigure(1, weight=1)
-        preprocess_widget = self._field(custom_grid, "preprocess_mode", self.custom_preprocess_mode, row=len(custom_specs), values=["none", "luma_bands"], readonly=True)
+        preprocess_widget = self._field(custom_grid, "preprocess_mode", self.custom_preprocess_mode, row=len(custom_specs), values=["none", "luma_band"], readonly=True)
         self.custom_fields.append(preprocess_widget)
         custom_actions = Frame(custom_section)
         custom_actions.pack(fill=X, padx=10, pady=(0, 8))
@@ -2432,7 +2432,7 @@ class App:
                             self.queue.put(("status", tr(self.lang, "stopped")))
                             return
                         _drain_generator_output()
-                        preview_files = generated_preview_files(image_path)
+                        preview_files = generated_preview_files(input_image)
                         if preview_files:
                             newest_preview = preview_files[0]
                             preview_mtime = newest_preview.stat().st_mtime

--- a/src/app.py
+++ b/src/app.py
@@ -24,7 +24,7 @@ import psutil
 from app_paths import ROOT, SOURCE_DIR
 from game_profiles import PROFILES
 from geometry_json import RECTANGLE, ROTATED_ELLIPSE, load_normalized_geometry
-from generator_backend import GENERATOR_EXE, USER_SETTINGS_DIR, best_geometry_jsons, build_generator_command, generated_jsons, generated_preview_files, generator_preview_path, load_settings, write_custom_settings, write_user_settings_preset
+from generator_backend import GENERATOR_EXE, USER_SETTINGS_DIR, best_geometry_jsons, build_generator_command, generated_jsons, generated_preview_files, generator_preview_path, load_settings, preprocess_input_image, write_custom_settings, write_user_settings_preset
 from version import APP_DISPLAY_NAME, __version__, app_title
 
 
@@ -88,6 +88,7 @@ TEXT = {
         "custom_random": "Random samples",
         "custom_mutated": "Mutated samples",
         "custom_save_at": "Save checkpoints",
+        "preprocess_mode": "Preprocess mode",
         "save_custom_preset": "Save as preset",
         "custom_panel_title": "Custom settings",
         "custom_panel_hint": "The selected preset fills these values. Enable custom settings if you want to edit them before generating.",
@@ -220,6 +221,7 @@ Notes
         "custom_random": "随机样本",
         "custom_mutated": "变异样本",
         "custom_save_at": "保存节点",
+        "preprocess_mode": "预处理模式",
         "save_custom_preset": "保存为预设",
         "custom_panel_title": "自定义参数",
         "custom_panel_hint": "上方预设会自动填入这些参数；勾选使用自定义参数后可直接修改。",
@@ -352,6 +354,7 @@ Notes
         "custom_random": "무작위 샘플",
         "custom_mutated": "변형 샘플",
         "custom_save_at": "체크포인트 저장",
+        "preprocess_mode": "전처리 모드",
         "save_custom_preset": "프리셋으로 저장",
         "custom_panel_title": "사용자 설정",
         "custom_panel_hint": "선택한 프리셋 값이 자동으로 채워집니다. 생성 전에 값을 바꾸려면 사용자 설정을 켜세요.",
@@ -881,6 +884,7 @@ class App:
         self.custom_random_samples = StringVar()
         self.custom_mutated_samples = StringVar()
         self.custom_save_at = StringVar()
+        self.custom_preprocess_mode = StringVar(value="none")
         self.translated = []
         self.detailed_log_lock = threading.Lock()
         self.detailed_log_lines = deque()
@@ -1310,6 +1314,8 @@ class App:
             entry.grid(row=row_index, column=1, sticky="ew", pady=1)
             self.custom_fields.append(entry)
         custom_grid.columnconfigure(1, weight=1)
+        preprocess_widget = self._field(custom_grid, "preprocess_mode", self.custom_preprocess_mode, row=len(custom_specs), values=["none", "luma_bands"], readonly=True)
+        self.custom_fields.append(preprocess_widget)
         custom_actions = Frame(custom_section)
         custom_actions.pack(fill=X, padx=10, pady=(0, 8))
         self._button(custom_actions, "save_custom_preset", self.save_custom_preset).pack(side=LEFT)
@@ -1476,6 +1482,7 @@ class App:
             self.custom_random_samples.set(values.get("randomSamples", "3000"))
             self.custom_mutated_samples.set(values.get("mutatedSamples", "1000"))
             self.custom_save_at.set(values.get("saveAt", values.get("stopAt", "3000")))
+            self.custom_preprocess_mode.set(values.get("preprocessMode", "none"))
 
     def _sync_custom_state(self):
         state = "normal" if self.use_custom_settings.get() == "1" else "disabled"
@@ -1497,6 +1504,7 @@ class App:
             "randomSamples": self.custom_random_samples.get(),
             "mutatedSamples": self.custom_mutated_samples.get(),
             "saveAt": self.custom_save_at.get(),
+            "preprocessMode": self.custom_preprocess_mode.get(),
         }
         if not custom["saveAt"] and custom["stopAt"]:
             custom["saveAt"] = custom["stopAt"]
@@ -2358,7 +2366,10 @@ class App:
                 self.queue.put(("log", f"Generating: {image_path}"))
                 self.queue.put(("preview_file", image_path))
                 flags = subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
-                cmd = build_generator_command(image_path, setting)
+                input_image = preprocess_input_image(image_path, setting)
+                if input_image != image_path:
+                    self.queue.put(("log", f"Preprocessed image: {input_image}"))
+                cmd = build_generator_command(input_image, setting)
                 self._record_detail(f"GENERATOR COMMAND: {self._format_command(cmd)}")
                 self.queue.put(("log", f"Running GPU generator with {setting['path'].name}"))
                 if self.shutdown_event.is_set():

--- a/src/generator_backend.py
+++ b/src/generator_backend.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from app_paths import RESOURCE_ROOT, ROOT
 from geometry_json import drawable_shape_count
-from preprocess.luma import luma_bands
+from preprocess.luma import luma_band
 
 
 BUNDLED_SETTINGS_DIR = RESOURCE_ROOT / "config" / "settings"
@@ -141,8 +141,7 @@ def _get_preprocess_mode(values):
 
 def _preprocessed_image_path(image_path, mode):
     image_path = Path(image_path)
-    # Save preprocessed file beside the original
-    return image_path.with_name(f"{image_path.stem}.{mode}.{image_path.suffix}")
+    return image_path.with_name(f"{image_path.stem}.{mode}{image_path.suffix}")
 
 
 def preprocess_input_image(image_path, setting):
@@ -160,8 +159,8 @@ def preprocess_input_image(image_path, setting):
         pass
     
     # Generate preprocessed image
-    if mode == "luma_bands":
-        return luma_bands(image_path)
+    if mode == "luma_band":
+        return luma_band(image_path)
     else:
         raise ValueError(f"unsupported preprocess mode: {mode}")
 
@@ -212,15 +211,18 @@ def best_geometry_jsons(paths):
 def generator_preview_path(image_path):
     PREVIEW_DIR.mkdir(parents=True, exist_ok=True)
     image_path = Path(image_path)
-    return PREVIEW_DIR / f"{image_path.stem}.preview.png"
+    name_without_suffix = _name_without_suffix(image_path)
+    return PREVIEW_DIR / f"{name_without_suffix}.preview.png"
 
 
 def generated_preview_files(image_path):
     image_path = Path(image_path)
     if not PREVIEW_DIR.exists():
         return []
+    # Match previews using full filename
+    name_without_suffix = _name_without_suffix(image_path)
     return sorted(
-        PREVIEW_DIR.glob(f"{image_path.stem}.preview*.png"),
+        PREVIEW_DIR.glob(f"{name_without_suffix}.preview*.png"),
         key=lambda path: path.stat().st_mtime,
         reverse=True,
     )
@@ -228,8 +230,13 @@ def generated_preview_files(image_path):
 
 def generator_output_base(image_path):
     image_path = Path(image_path)
-    safe_stem = image_path.stem.replace(".", "_")
-    return image_path.with_name(safe_stem)
+    name_without_suffix = _name_without_suffix(image_path)
+    return image_path.with_name(name_without_suffix)
+
+
+def _name_without_suffix(path):
+    path = Path(path)
+    return path.name[:-len(path.suffix)] if path.suffix else path.name
 
 
 def build_generator_command(image_path, setting):

--- a/src/generator_backend.py
+++ b/src/generator_backend.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from app_paths import RESOURCE_ROOT, ROOT
 from geometry_json import drawable_shape_count
+from preprocess.luma import luma_bands
 
 
 BUNDLED_SETTINGS_DIR = RESOURCE_ROOT / "config" / "settings"
@@ -22,6 +23,7 @@ SETTING_KEYS = (
     "posterizeLevels",
     "previewEvery",
     "randomSamples",
+    "preprocessMode",
     "saveAt",
     "saveEvery",
     "stopAt",
@@ -126,6 +128,42 @@ def write_user_settings_preset(base_setting, custom_values, output_path, descrip
             lines.append(f"{key} = {values[key]}")
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return path
+
+
+def _get_preprocess_mode(values):
+    if not values:
+        return None
+    preprocess_mode = str(values.get("preprocessMode", "")).strip().lower()
+    if preprocess_mode == "none" or not preprocess_mode:
+        return None
+    return preprocess_mode
+
+
+def _preprocessed_image_path(image_path, mode):
+    image_path = Path(image_path)
+    # Save preprocessed file beside the original
+    return image_path.with_name(f"{image_path.stem}.{mode}.{image_path.suffix}")
+
+
+def preprocess_input_image(image_path, setting):
+    image_path = Path(image_path)
+    mode = _get_preprocess_mode(setting.get("values", {}))
+    if mode is None:
+        return image_path
+
+    # Generate output path
+    output_path = _preprocessed_image_path(image_path, mode)
+    try:
+        if output_path.exists() and output_path.stat().st_mtime >= image_path.stat().st_mtime:
+            return output_path
+    except OSError:
+        pass
+    
+    # Generate preprocessed image
+    if mode == "luma_bands":
+        return luma_bands(image_path)
+    else:
+        raise ValueError(f"unsupported preprocess mode: {mode}")
 
 
 def generated_jsons(image_path):

--- a/src/preprocess/luma.py
+++ b/src/preprocess/luma.py
@@ -2,13 +2,13 @@ import cv2
 import numpy as np
 from pathlib import Path
 
-def luma_bands(image_path):
+def luma_band(image_path):
     image_path = Path(image_path)
     rgba = cv2.imread(str(image_path), cv2.IMREAD_UNCHANGED)
     if rgba is None:
         raise ValueError(f"failed to read image: {image_path}")
     result = _apply_preprocess(rgba)
-    output_path = image_path.with_name(f"{image_path.stem}.luma_bands{image_path.suffix}")
+    output_path = image_path.with_name(f"{image_path.stem}.luma_band{image_path.suffix}")
     cv2.imwrite(str(output_path), result)
     return output_path
 

--- a/src/preprocess/luma.py
+++ b/src/preprocess/luma.py
@@ -1,0 +1,32 @@
+import cv2
+import numpy as np
+from pathlib import Path
+
+def luma_bands(image_path):
+    image_path = Path(image_path)
+    rgba = cv2.imread(str(image_path), cv2.IMREAD_UNCHANGED)
+    if rgba is None:
+        raise ValueError(f"failed to read image: {image_path}")
+    result = _apply_preprocess(rgba)
+    output_path = image_path.with_name(f"{image_path.stem}.luma_bands{image_path.suffix}")
+    cv2.imwrite(str(output_path), result)
+    return output_path
+
+def _apply_preprocess(rgba: np.ndarray) -> np.ndarray:
+    rgb = np.clip(rgba[..., :3], 0, 255).astype(np.uint8)
+    alpha = np.clip(rgba[..., 3], 0, 255).astype(np.uint8)
+    lab = cv2.cvtColor(rgb, cv2.COLOR_RGB2LAB)
+    l = lab[..., 0].astype(np.float32)
+    levels = 24.0  # TODO make this a setting
+    step = 256.0 / levels
+    lq = np.floor(l / step) * step + step * 0.5
+    # Keep the band separation, but blend some original luminance back in
+    # so the result stays closer to the source and avoids overly harsh steps.
+    l_out = lq * 0.82 + l * 0.18
+    # Restore a touch of local contrast so the pass doesn't feel slightly washed.
+    l_mid = 128.0
+    l_out = (l_out - l_mid) * 1.06 + l_mid
+    lab[..., 0] = np.clip(l_out, 0, 255).astype(np.uint8)
+    rgb_out = cv2.cvtColor(lab, cv2.COLOR_LAB2RGB)
+    out = np.dstack([rgb_out, alpha]).astype(np.float32)
+    return out


### PR DESCRIPTION
Add luma band preprocessing based on Kloudy's implementation (Discord: kloudy1811)

By default it's turned on in all configs because it seems to get better results.

<img width="921" height="332" alt="image" src="https://github.com/user-attachments/assets/67407459-3310-45a7-b339-0b5eb339d5bb" />

 It runs a luma band pass against the input image, outputs it to the output folder, then calls the generator on that file instead. Gets better detailed results sooner by avoiding wasting layers on gradients. Has little impact on quality if there's no gradients to begin with.

With luma band preprocessing
<img width="600" height="560" alt="luma_band_preprocess" src="https://github.com/user-attachments/assets/73bff61f-94d4-4f21-b1bc-1dd44dd4ece2" />

Without preprocessing
<img width="600" height="560" alt="no_preprocess" src="https://github.com/user-attachments/assets/543ce139-8d3a-4978-bd22-47ac3af7c749" />
