### PR TITLE
support float width and hight for the ellipse

### DIFF
--- a/src/geometry_json.py
+++ b/src/geometry_json.py
@@ -159,8 +159,8 @@ def _normalize_data(shape, type_id):
         return None
 
     if type_id == ShapeType.RECTANGLE:
-        return [round(x), round(y), max(0, round(w)), max(0, round(h))]
-    return [round(x), round(y), max(1, round(w)), max(1, round(h)), round(rot) % 360]
+        return [round(x), round(y), max(0.0, w), max(0.0, h)]
+    return [round(x), round(y), max(1.0, w), max(1.0, h), round(rot) % 360]
 
 
 def _normalize_color(value):

--- a/src/internal_classes.py
+++ b/src/internal_classes.py
@@ -36,8 +36,8 @@ class Shape:
     type_id: int
     x: int
     y: int
-    w: int
-    h: int
+    w: float
+    h: float
     rot_deg: int
     color: Color
     is_mask: bool

--- a/src/main.py
+++ b/src/main.py
@@ -225,16 +225,16 @@ def load_geometry(
     loaded = load_cv2()
     if loaded:
         cv2, np = loaded
-        preview = np.zeros((image_h, image_w, 3), np.uint8)
+        preview = np.zeros((int(image_h), int(image_w), 3), np.uint8)
         if bg_a > 0:
-            preview = cv2.rectangle(preview, (0,0), (image_w, image_h), (bg_b, bg_g, bg_r), thickness=-1)
+            preview = cv2.rectangle(preview, (0,0), (int(image_w), int(image_h)), (bg_b, bg_g, bg_r), thickness=-1)
         else:
             preview[:, :] = (38, 38, 38)
         for shape in shapes:
             if shape.color.a <= 0:
                 continue
             if shape.type_id == ROTATED_ELLIPSE:
-                preview = cv2.ellipse(preview, (shape.x, shape.y), (shape.h,shape.w), -90 + shape.rot_deg, 0., 360, (shape.color.b, shape.color.g, shape.color.r), thickness=-1)
+                preview = cv2.ellipse(preview, (shape.x, shape.y), (int(shape.h), int(shape.w)), -90 + shape.rot_deg, 0., 360, (shape.color.b, shape.color.g, shape.color.r), thickness=-1)
             elif shape.type_id == RECTANGLE:
                 x0 = int(round(shape.x - shape.w / 2))
                 y0 = int(round(shape.y - shape.h / 2))
@@ -304,10 +304,10 @@ def load_geometry(
     # with a blank cover, paste blank onto the car, or recover only after the
     # user manually moves the group.
     boundary_masks = [
-        Shape(1, -int(image_w//4), int(image_h//2), int(image_w//2), int(image_h*1.5), 0, Color(0,0,0,255), True),
-        Shape(1, image_w + int(image_w//4), int(image_h//2), int(image_w//2), int(image_h*1.5), 0, Color(0,0,0,255), True),
-        Shape(1, int(image_w//2), -int(image_h//4), image_w + int(image_w), int(image_h//2), 0, Color(0,0,0,255), True),
-        Shape(1, int(image_w//2), image_h + int(image_h//4), image_w + int(image_w), int(image_h//2), 0, Color(0,0,0,255), True),
+        Shape(1, -int(image_w//4), int(image_h//2), float(image_w//2), float(image_h*1.5), 0, Color(0,0,0,255), True),
+        Shape(1, image_w + int(image_w//4), int(image_h//2), float(image_w//2), float(image_h*1.5), 0, Color(0,0,0,255), True),
+        Shape(1, int(image_w//2), -int(image_h//4), float(image_w + image_w), float(image_h//2), 0, Color(0,0,0,255), True),
+        Shape(1, int(image_w//2), image_h + int(image_h//4), float(image_w + image_w), float(image_h//2), 0, Color(0,0,0,255), True),
     ]
     reserved_mask_layers = len(boundary_masks)
     drawable_capacity = max(0, min(int(current_livery_count), 3000) - reserved_mask_layers)


### PR DESCRIPTION
参考 https://github.com/zjl88858/forza-painter-geometrize-gpu/issues/9 里描述的问题，原本的宽与高只能是整数，这就导致当 json 中的宽与高换算成游戏里 “直径 63 像素的圆形长宽倍率” 时，长与宽的倍率会因为游戏内的两位小数限制而出现误差（两位小数看下图示例）。

这个 PR 主要的改动就是把宽与高从整数改成浮点数，这样在 https://github.com/zjl88858/forza-painter-geometrize-gpu 计算出带浮点数但误差更小的宽与高时导入器能做对应支持。不改的话即使计算出精确的浮点数宽高也会因为这里只取整数而产生误差。

<img width="434" height="253" alt="image" src="https://github.com/user-attachments/assets/aae68d80-c65e-435b-881e-3bf9b187d1a8" />

当然，也有代价。我们在预览时是把椭圆渲染到 `cv` 的画布里，而这个画布只支持整数。所以在预览时会因为误差变大而质量变低一点。不过我觉得这个代价可以接受，毕竟预览时效果差一点比导入游戏以后效果差一点要好。更何况我们以后还可以想办法找到更合适的库来生成预览以绕过整数的限制。